### PR TITLE
Fix CLI name in quickstart and mark feature as coming soon

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -90,15 +90,15 @@ This quickstart guide will help you integrate Routstr into your application quic
     }
     ```
   </Step>
-  <Step title="Monitor and scale">
+  <Step title="Monitor and scale (coming soon)">
     Track usage, set custom pricing, and join the relay network to get discovered by users automatically:
-    
+
     ```bash
     # Announce your provider to the Nostr network
-    routstr-proxy announce --name "Your Provider" --models "gpt-4,llama-3"
-    
+    routstr announce --name "Your Provider" --models "gpt-4,llama-3"
+
     # Monitor usage statistics
-    routstr-proxy stats
+    routstr stats
     ```
   </Step>
 </Steps>


### PR DESCRIPTION
## Summary
- correct CLI name from `routstr-proxy` to `routstr`
- label the provider monitoring step as coming soon

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dfe59a02083209442241874835369